### PR TITLE
:pencil: Correção ortográfica

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ O commit semântico possui os elementos estruturais abaixo (tipos), que informam
 
 - `fix` - Commits do tipo fix indicam que seu trecho de código commitado está solucionando um problema (bug fix), (se relaciona com o PATCH do versionamento semântico).
 
-- `feat`- Commits do tipo feat indicam que seu trecho de código está incuindo um novo recurso (se relaciona com o MINOR do versionamento semântico).
+- `feat`- Commits do tipo feat indicam que seu trecho de código está incluindo um novo recurso (se relaciona com o MINOR do versionamento semântico).
 
 - `docs` - Commits do tipo docs indicam que houveram mudanças na documentação, como por exemplo no Readme do seu repositório. (Não inclui alterações em código).
 
@@ -35,7 +35,7 @@ O commit semântico possui os elementos estruturais abaixo (tipos), que informam
 
 - `build` - Commits do tipo build são utilizados quando são realizadas modificações em arquivos de build e dependências.
 
-- `teste` - Commits do tipo test são utilizados quando são realizadas alterações em testes, seja criando, alterando ou excluindo testes unitários. (Não inclui alterações em código)
+- `test` - Commits do tipo test são utilizados quando são realizadas alterações em testes, seja criando, alterando ou excluindo testes unitários. (Não inclui alterações em código)
 
 - `chore` - Commits do tipo chore indicam atualizações de tarefas de build, configurações de administrador, pacotes... como por exemplo adicionar um pacote no gitignore. (Não inclui alterações em código)
 
@@ -44,14 +44,14 @@ O commit semântico possui os elementos estruturais abaixo (tipos), que informam
 
 - Adicione um título consistente com o título do conteúdo;
 - Recomendamos que na primeira linha deve ter no máximo 4 palavras;
-- Para descrever com detalhes usar a descrição do commit;
+- Para descrever com detalhes, usar a descrição do commit;
 - Usar um emoji no início da mensagem de commit representando sobre o commit;
 - Um link precisa ser adicionado em sua forma mais autêntica, ou seja: sem encurtadores de link e link safiliados;
 
 ## 💻 Exemplo
 ```bash
 git commit -m ":tada: Meu primeiro commit"
-``` 
+```
 
 ## 💈 Padrões de emojis
 


### PR DESCRIPTION
- Correção da palavra `incluindo` que estava escrita incorretamente como `incuindo`.
- Correção da palavra `teste` para `test` pois estava fora do padrão das demais que se encontrava em inglês.