### PR TITLE
:pencil: Correção ortográfica

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ O commit semântico possui os elementos estruturais abaixo (tipos), que informam
 - Recomendamos que na primeira linha deve ter no máximo 4 palavras;
 - Para descrever com detalhes, usar a descrição do commit;
 - Usar um emoji no início da mensagem de commit representando sobre o commit;
-- Um link precisa ser adicionado em sua forma mais autêntica, ou seja: sem encurtadores de link e link safiliados;
+- Um link precisa ser adicionado em sua forma mais autêntica, ou seja: sem encurtadores de link e links afiliados;
 
 ## 💻 Exemplo
 ```bash


### PR DESCRIPTION
Correção da palavra links afiliados que estava escrita incorretamente como link safiliados.