### PR TITLE
Corrigindo erro de digitação no 'README.md'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 </h1>
 
 <p>
-  De acordo com a documentação do <strong>Convetional Commits</strong>, Commits Semânticos são uma convenção simples para ser utilizada nas mensagens de commit. Essa convenção define  um conjunto de regras para criar um histórico de commit explícito, o que facilita a criação de ferramentas automatizadas.
+  De acordo com a documentação do <strong>Conventional Commits</strong>, Commits Semânticos são uma convenção simples para ser utilizada nas mensagens de commit. Essa convenção define  um conjunto de regras para criar um histórico de commit explícito, o que facilita a criação de ferramentas automatizadas.
 </p>
 
 <p>


### PR DESCRIPTION
No arquivo 'README.md' havia um erro de digitação. Estava escrito `Convetional` ao inves de `Conventional`. Minha alteração é somente corrigir este erro.