### PR TITLE
:pencil: correção de exemplos duplicados

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,13 +250,13 @@ O commit semântico possui os elementos estruturais abaixo (tipos), que informam
     </tr>
     <tr>
       <td>
-        <code>git commit -m ":test_tube: feat: Estilizaçao CSS do formulario"</code>
+        <code>git commit -m ":test_tube: test: Criando novo teste"</code>
       </td>
       <td>🧪 test: Criando novo teste</td>
     </tr>
     <tr>
       <td>
-        <code>git commit -m ":test_tube: feat: Estilizaçao CSS do formulario"</code>
+        <code>git commit -m ":bulb: docs: Comentários sobre a função LoremIpsum( )"</code>
       </td>
       <td>💡 docs: Comentários sobre a função LoremIpsum( )</td>
     </tr>


### PR DESCRIPTION
O comando dos ultimos dois exemplos estão duplicados. :smile: 

Comando git | Resultado no GitHub
-- | --
git commit -m ":lipstick: feat: Estilizaçao CSS do formulario" | feat: Estilizaçao CSS do formulario
git commit -m ":test_tube: feat: Estilizaçao CSS do formulario" | test: Criando novo teste
git commit -m ":test_tube: feat: Estilizaçao CSS do formulario" | docs: Comentários sobre a função LoremIpsum( )

Com as correções, eles ficam como:

Comando git | Resultado no GitHub
-- | --
git commit -m ":lipstick: feat: Estilizaçao CSS do formulario" | feat: Estilizaçao CSS do formulario
git commit -m ":test_tube: test: Criando novo teste" | test: Criando novo teste
git commit -m ":bulb: docs: Comentários sobre a função LoremIpsum( )" | docs: Comentários sobre a função LoremIpsum( )