### PR TITLE
:pencil: fix: Consertando escrita de emoji

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ O commit semântico possui os elementos estruturais abaixo (tipos), que informam
     </tr>
     <tr>
       <td>
-        <code>git commit -m ":bulb: raw: RAW Data do ano aaaa"</code>
+        <code>git commit -m ":card_file_box: raw: RAW Data do ano aaaa"</code>
       </td>
       <td>🗃️ raw: RAW Data do ano aaaa</td>
     </tr>


### PR DESCRIPTION
Foi mudado a escrita do emoji no exemplo do tipo `raw`, que estava `:bulb:` (💡) e agora está `:card_file_box:` (🗃️), o que condiz com a exibição da mensagem e com o tipo do commit.