### PR TITLE
:books: fix: Encapsulando palavra-chave "remove"

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ O commit semântico possui os elementos estruturais abaixo (tipos), que informam
     <tr>
       <td>Removendo um arquivo</td>
       <td>🗑️ <code>:wastebasket:</code></td>
-      <td>remove</td>
+      <td><code>remove</code></td>
     </tr>
     <tr>
       <td>Removendo uma dependência</td>


### PR DESCRIPTION
Encapsulando palavra-chave _remove_, da tabela [**Padrões de emojis**](https://github.com/iuricode/padroes-de-commits?tab=readme-ov-file#padr%C3%B5es-de-emojis-), com a _tag_ ```code```. 