### PR TITLE
feat: inclusão de githook para commitar usando chatGPT

### DIFF
--- a/prepare-commit-msg.sh
+++ b/prepare-commit-msg.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+# Implemente o serviço em https://github.com/tiagolofi/ai-commit-hooks-api
+# Mais detalhes em: https://github.com/tiagolofi/ai-commit-hooks
+
+COMMIT_MSG_FILE=$1
+
+GIT_DIFF=$(git diff --staged)
+
+API_RESPONSE=$(
+    curl -X 'POST' \
+    'http://localhost:8080/commit/gpt-4o-mini' \
+    -H 'Token-Consumo: SEU_TOKEN_GERADO_NA_APLICACAO' \
+    -H 'Content-Type: text/plain' \
+    -d "$GIT_DIFF"
+)
+
+COMMIT=$(echo $API_RESPONSE | grep -o '"respostaGPT4oMini": *"[^"]*"' | awk -F'"' '{print $4}')
+
+echo "$COMMIT" > temp_msg
+cat "$COMMIT_MSG_FILE" >> temp_msg # dê um " " na mensagem de commit
+mv temp_msg "$COMMIT_MSG_FILE"
+COMMIT_MSG=$(cat "$COMMIT_MSG_FILE")
+if [[ -z "$COMMIT_MSG" || "$COMMIT_MSG" =~ ^[[:space:]]*$ ]]; then
+    exit 1 # erro: mensagem vazia
+fi


### PR DESCRIPTION
Este script é um hook de commit para Git. Ele faz o seguinte:

1. Obtém as diferenças dos arquivos staged (git diff --staged);
2. Envia essas diferenças para uma API que gera uma mensagem de commit usando GPT-4;
3. Extrai a resposta da API e a adiciona ao arquivo de mensagem de commit e;
4. Verifica se a mensagem de commit não está vazia antes de finalizar.