### PR TITLE
:books: docs: Adição do comando git cherry-pick hash-do-commit ao Glossário

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,7 +349,7 @@ O commit semântico possui os elementos estruturais abaixo (tipos), que informam
 
 - `git add .` - Adiciona todos os arquivos e alterações no diretório atual para a área de stage (preparando-os para o commit).
 
-- `git commit -m "mensagem do commit"` - Registra as alterações adicionadas na área de stage com uma mensagem descritiva sobre o que foi modificado. 
+- `git commit -m "mensagem do commit"` - Registra as alterações adicionadas na área de stage com uma mensagem descritiva sobre o que foi modificado.
 
 - `git branch -M main` - Renomeia a branch atual (master) para main. O -M é usado para forçar a renomeação, movendo a branch se necessário.
 
@@ -361,7 +361,7 @@ O commit semântico possui os elementos estruturais abaixo (tipos), que informam
 
 - `git fetch` - Busca todas as atualizações do repositório remoto sem integrá-las à branch atual. Isso atualiza as referências remotas.
 
-- `git pull origin main`  - Atualiza a branch local main com as mudanças do repositório remoto origin. Combina git fetch e git merge.
+- `git pull origin main` - Atualiza a branch local main com as mudanças do repositório remoto origin. Combina git fetch e git merge.
 
 - `git push --force-with-lease` - Forma mais segura de forçar o envio de alterações locais para o repositório remoto. Verifica se não houve alterações feitas por outros colaboradores desde sua última atualização local, evitando sobrescrever acidentalmente o trabalho de outros.
 
@@ -370,6 +370,8 @@ O commit semântico possui os elementos estruturais abaixo (tipos), que informam
 - `git reset --hard id_do_commit_anterior_ao_que_vai_ser_apagado` - Redefine o repositório para o estado do commit especificado, apagando todas as mudanças feitas após esse commit. Ideal para uso local. Para sincronizar remotamente, use `git push --force-with-lease` posteriormente.
 
 - `git commit --amend -m "mensagem_reescrita"` - Altera a mensagem do último commit. Após usar este comando, sincronize remotamente com `git push --force-with-lease`.
+
+- `git cherry-pick HASH_DO_COMMIT` - Utilizado para obter um commit específico. Exemplo de uso: Imagine que você tenha duas branchs (main) e (develop) e na segunda você tem 3 commits mas deseja apenas pegar o primeiro commit dela, com o uso de cherry-pick você pode.
 
 # Glossário 📖
 


### PR DESCRIPTION
Contribuindo pela primeira vez utilizando os padrões de commit e trazendo um comando interessante para a comunidade. 